### PR TITLE
Refactored logging levels, exceptions streamed to console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [3.11.0] - 17-09-2018
+### Changed
+- 400 responses will be warning level
+- 500 responses will be error level
+- All exceptions will be printed on console when there is no `DISABLE_CONSOLE_ERROR` config.
+
 # [3.10.0] - 013-08-2018
 ### Added
 - dnscache wrapper with 2000 ms ttl.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puzzle-microfrontends",
-  "version": "3.10.6",
+  "version": "3.11.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -24,7 +24,7 @@ const alignedWithColorsAndTime = winston.format.combine(
  */
 const createTransports = () => {
   const transports = [];
-  if (process.env.NODE_ENV !== 'production') {
+  if(!process.env.DISABLE_CONSOLE_ERROR){
     transports.push(new winston.transports.Console({
       level: process.env.logLevel || 'warn',
       handleExceptions: false,
@@ -32,7 +32,9 @@ const createTransports = () => {
       colorize: true,
       format: alignedWithColorsAndTime
     }));
-  } else if (process.env.GRAYLOG_HOST && process.env.GRAYLOG_PORT && process.env.GRAYLOG_HOSTNAME && process.env.GRAYLOG_FACILITY) {
+  }
+
+  if (process.env.GRAYLOG_HOST && process.env.GRAYLOG_PORT && process.env.GRAYLOG_HOSTNAME && process.env.GRAYLOG_FACILITY) {
     transports.push(new WinstonGraylog2({
       name: 'Graylog',
       level: process.env.logLevel || 'warn',
@@ -104,7 +106,13 @@ export class Logger {
   }
 
   write(message: string) {
-    const level = message.match(/RES: [4|5]/) ? 'error' : 'info';
+    let level = 'info';
+    if (message.match(/RES: [4]/)) {
+      level = 'warn'
+    } else if (message.match(/RES: [5]/)) {
+      level = 'error'
+    }
+
     logger[level](message);
   }
 }


### PR DESCRIPTION
#### What's this PR do?
- 400 responses will be warning level
- 500 responses will be error level
- All exceptions will be printed on console when there is no `DISABLE_CONSOLE_ERROR` config.

